### PR TITLE
Use aliases and simplify installing php extensions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,78 +1,76 @@
 sudo: false
-language: none
+language: php
 
 env:
   global:
     - COMPOSER_ARGS="--no-interaction"
     - ADAPTER_DEPS="alcaeus/mongo-php-adapter"
     - COVERAGE_DEPS="php-coveralls/php-coveralls"
-    - MONGO_DRIVER="mongodb"
 
 matrix:
   include:
-    - env:
-        - PHP_VERSION=5.6
+    - php: 5.6
+      env:
         - DEPS=lowest
-        - MONGO_DRIVER="mongo"
-    - env:
-        - PHP_VERSION=5.6
+    - php: 5.6
+      env:
         - DEPS=locked
         - LEGACY_DEPS="doctrine/doctrine-module doctrine/doctrine-orm-module phpunit/phpunit zendframework/zend-code"
-        - MONGO_DRIVER="mongo"
-    - env:
-        - PHP_VERSION=5.6
+    - php: 5.6
+      env:
         - DEPS=latest
-        - MONGO_DRIVER="mongo"
-    - env:
-        - PHP_VERSION=7
+    - php: 7
+      env:
         - DEPS=lowest
-    - env:
-        - PHP_VERSION=7
+    - php: 7
+      env:
         - DEPS=locked
         - LEGACY_DEPS="doctrine/doctrine-module doctrine/doctrine-orm-module phpunit/phpunit zendframework/zend-code"
-    - env:
-        - PHP_VERSION=7
+    - php: 7
+      env:
         - DEPS=latest
-    - env:
-        - PHP_VERSION=7.1
+    - php: 7.1
+      env:
         - DEPS=lowest
-    - env:
-        - PHP_VERSION=7.1
+    - php: 7.1
+      env:
         - DEPS=locked
         - CS_CHECK=true
         - TEST_COVERAGE=true
-        - XDEBUG=1
-    - env:
-        - PHP_VERSION=7.1
+    - php: 7.1
+      env:
         - DEPS=latest
-    - env:
-        - PHP_VERSION=7.2
+    - php: 7.2
+      env:
         - DEPS=lowest
-    - env:
-        - PHP_VERSION=7.2
+    - php: 7.2
+      env:
         - DEPS=locked
-    - env:
-        - PHP_VERSION=7.2
+    - php: 7.2
+      env:
         - DEPS=latest
 
 before_install:
-  - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
+  - shopt -s expand_aliases
+  - alias composer="travis_retry docker-compose run --rm php composer"
+  - alias php="travis_retry docker-compose run --rm php php"
+  - docker-compose build --build-arg PHP_VERSION=${TRAVIS_PHP_VERSION} --build-arg XDEBUG=${TEST_COVERAGE:+1} --no-cache php
+  - composer --version
+  - php -v
+  - php -m
 
 install:
-  - docker-compose build --no-cache php
-  - travis_retry docker-compose run --rm php composer install $COMPOSER_ARGS --ignore-platform-reqs
-
-  - composer config "platform.ext-mongo" "1.6.16"
-  - if [[ $LEGACY_DEPS != '' ]]; then travis_retry docker-compose run --rm php composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
-  - if [[ $DEPS == 'latest' ]]; then travis_retry docker-compose run --rm php composer update $COMPOSER_ARGS ; fi
-  - if [[ $DEPS == 'lowest' ]]; then travis_retry docker-compose run --rm php composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
-  - if [[ $MONGO_DRIVER == 'mongodb' ]] ; then travis_retry docker-compose run --rm php composer config "platform.ext-mongo" "1.6.16" && travis_retry docker-compose run --rm php composer require --dev $COMPOSER_ARGS $ADAPTER_DEPS ; fi
-  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry docker-compose run --rm php composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi
+  - composer install $COMPOSER_ARGS --ignore-platform-reqs
+  - if [[ $LEGACY_DEPS != '' ]]; then composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
+  - if [[ $DEPS == 'latest' ]]; then composer update $COMPOSER_ARGS ; fi
+  - if [[ $DEPS == 'lowest' ]]; then composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
+  - if [[ $TRAVIS_PHP_VERSION != "5.6" ]] ; then composer require --dev $COMPOSER_ARGS $ADAPTER_DEPS ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi
   - stty cols 120 && composer show
 
 script:
-  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry docker-compose run --rm php composer test-coverage ; else docker-compose run --rm php composer test ; fi
-  - if [[ $CS_CHECK == 'true' ]]; then travis_retry docker-compose run --rm php composer cs-check ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; else composer test ; fi
+  - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
 
 after_script:
-  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry docker-compose run --rm php vendor/bin/php-coveralls -v ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then php vendor/bin/php-coveralls -v ; fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,6 @@
 ARG PHP_VERSION=7.2
-FROM php:${PHP_VERSION}-alpine
-
 ARG XDEBUG=0
+FROM php:${PHP_VERSION}-alpine
 
 RUN apk add --no-cache \
 	autoconf \
@@ -11,15 +10,19 @@ RUN apk add --no-cache \
 	git \
 	openssl-dev
 
-RUN echo "memory_limit=2G" >> 'test' >> `php --ini | sed -n -e 's/^.*Path: //p'`/php.ini
+RUN echo -e 'memory_limit=2G' > /usr/local/etc/php/conf.d/memory.ini
 RUN set -o pipefail && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-RUN if [ ${PHP_VERSION:0:3} == "5.6" ] ; then pecl -q install -f mongo && echo "extension=mongo.so" >> `php --ini | sed -n -e 's/^.*Path: //p'`/php.ini ; fi
-RUN if [ ${PHP_VERSION:0:1} == "7" ] ; then pecl config-set php_ini `php --ini | sed -n -e 's/^.*Path: //p'`/php.ini && pecl install mongodb && docker-php-ext-enable mongodb && echo "extension=mongodb.so" >> `php --ini | sed -n -e 's/^.*Path: //p'`/php.ini; fi
-RUN if [ ${XDEBUG} == "1" ] ; then pecl config-set php_ini `php --ini | sed -n -e 's/^.*Path: //p'`/php.ini && pecl -q install -f xdebug && docker-php-ext-enable xdebug && echo "zend_extension=xdebug.so" >> `php --ini | sed -n -e 's/^.*Path: //p'`/php.ini ; fi
+RUN if [ ${PHP_VERSION:0:3} == "5.6" ] ; then \
+        pecl install mongo && docker-php-ext-enable mongo ; \
+    else \
+        pecl install mongodb && docker-php-ext-enable mongodb ; \
+    fi
+RUN if [ ${XDEBUG} == "1" ] ; then pecl install xdebug && docker-php-ext-enable xdebug ; fi
+RUN composer config --global "platform.ext-mongo" "1.999" ;
+
 RUN echo -e '#!/bin/sh ' > /usr/local/bin/entrypoint.sh \
     && echo -e 'while ! nc -z ${MONGO_HOST:-mongo} ${MONGO_PORT:-27017}; do sleep 1; done' >> /usr/local/bin/entrypoint.sh \
     && echo -e 'exec "$@"' >> /usr/local/bin/entrypoint.sh \
     && chmod +x /usr/local/bin/entrypoint.sh
 WORKDIR /docker
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
-CMD ["./vendor/bin/phpunit"]


### PR DESCRIPTION
If we use `language: none` php and composer are installed there anyway, so I think it's better to use travis php images, then we have clearer build lists - and then we are using just `$TRAVIS_PHP_VERSION`.

We don't need `MONGO_DRIVER` variable in travis, as all should be configured in docker (we need some customization between different PHP versions).

We don't need another `XDEBUG` variable in travis, we need xdebug only to generate coverage.

We can use aliases, but these were not available by default, and we need to use: `shopt -s expand_aliases`.

Installation php modules could be simplified just to use `docker-php-ext-enable`.